### PR TITLE
Move logic to set a specific pack namespace to its own method.

### DIFF
--- a/lib/automatic_namespaces/autoloader.rb
+++ b/lib/automatic_namespaces/autoloader.rb
@@ -6,16 +6,20 @@ class AutomaticNamespaces::Autoloader
 
   def enable_automatic_namespaces
     namespaced_packages.each do |pack, metadata|
-      package_namespace = define_namespace(pack, metadata)
-      pack_directories(pack.path, metadata).each do |pack_dir|
-        set_namespace_for(pack_dir, package_namespace)
-      end
+      set_namespace_for_pack(pack, metadata)
+    end
+  end
+
+  def set_namespace_for_pack(pack, metadata)
+    package_namespace = define_namespace(pack, metadata)
+    pack_directories(pack.path, metadata).each do |pack_dir|
+      set_namespace_for_dir(pack_dir, package_namespace)
     end
   end
 
   private
 
-  def set_namespace_for(pack_dir, package_namespace)
+  def set_namespace_for_dir(pack_dir, package_namespace)
     Rails.logger.debug { "Associating #{pack_dir} with namespace #{package_namespace}" }
     ActiveSupport::Dependencies.autoload_paths.delete(pack_dir)
     Rails.autoloaders.main.push_dir(pack_dir, namespace: package_namespace)


### PR DESCRIPTION
### Context
Applications might want to enforce automatic namespaces based on certain criteria specific to their `package.yml`, let's say, `version: v2`, or any other application-specific property. By exposing a public method to do the namespacing, applications can call this method rather than duplicating the code from this gem. 

### Changes
- Extract loop logic into its own method where we can define a namespace per pack/metadata
- Renaming set namespacing method for clarity given the new changes