### PR TITLE
Option for loading files at package root

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    automatic_namespaces (0.4.0)
+    automatic_namespaces (0.5.0)
       activesupport
       packs-rails
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ If bundler is not being used to manage dependencies, install the gem by executin
 
 Given the `package.yml` of a strongly namespaced pack:
 
-```
+```yml
 enforce_dependencies: true
 enforce_privacy: true
 public_path: app/public/
@@ -72,7 +72,7 @@ metadata:
 
 modify the metadata to opt into automatic namespacing:
 
-```
+```yml
 metadata:
  automatic_pack_namespace: true
 ```
@@ -99,7 +99,7 @@ metadata:
 If your package / namespace name requires ActiveSupport inflections, you will probably need to tell `automatic_namespaces`
 what the correct namespace name should be in that package:
 
-```
+```yml
 # packs/shoes_ui/package.yml
 metadata:
   automatic_pack_namespace: true
@@ -108,6 +108,16 @@ metadata:
 
 This is necessary because `automatic_namespaces` works by modifying the autoloader paths, which has to 
 happen during Rails application initialization; but the inflector is not available for use then.
+
+If you would like to use your own file layout conventions for packs (i.e. not `app/*`) you can specify 
+your own glob by using `autoload_glob` to append the glob to the folder containing package.yml. This defaults
+to `'/**/app/*'` 
+
+```yml
+metadata:
+  # Put the folder containing package.yml as the root for the autoloader.
+  autoload_glob: ''
+```
 
 ## Development
 

--- a/lib/automatic_namespaces/autoloader.rb
+++ b/lib/automatic_namespaces/autoloader.rb
@@ -27,7 +27,8 @@ class AutomaticNamespaces::Autoloader
   end
 
   def pack_directories(pack_root_dir, metadata)
-    Dir.glob("#{pack_root_dir}/**/app/*").select { |dir| namespaced_directory?(dir, metadata) }
+    glob = metadata['autoload_glob'] || "/**/app/*"
+    Dir.glob("#{pack_root_dir}#{glob}").select { |dir| namespaced_directory?(dir, metadata) }
   end
 
   def namespaced_directory?(dir, metadata)

--- a/lib/automatic_namespaces/version.rb
+++ b/lib/automatic_namespaces/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module AutomaticNamespaces
-  VERSION = "0.4.0"
+  VERSION = "0.5.0"
 end

--- a/spec/automatic_namespaces_spec.rb
+++ b/spec/automatic_namespaces_spec.rb
@@ -49,4 +49,10 @@ RSpec.describe AutomaticNamespaces do
       expect(defined?(Sneaker)).to eq("constant")
     end
   end
+
+  it "can find classes that are located at the root of the package.yml" do
+    expect(defined?(Summer::Fun)).to eq("constant")
+    expect(defined?(Summer::Swim)).to eq("constant")
+    expect(defined?(Summer::Swim::Trunks)).to eq("constant")
+  end
 end

--- a/spec/fixtures/rails-7.0/packs/summer/app/domain/fun.rb
+++ b/spec/fixtures/rails-7.0/packs/summer/app/domain/fun.rb
@@ -1,0 +1,1 @@
+module Summer::Fun; end

--- a/spec/fixtures/rails-7.0/packs/summer/package.yml
+++ b/spec/fixtures/rails-7.0/packs/summer/package.yml
@@ -1,0 +1,2 @@
+metadata:
+  automatic_pack_namespace: true

--- a/spec/fixtures/rails-7.0/packs/summer/swim/package.yml
+++ b/spec/fixtures/rails-7.0/packs/summer/swim/package.yml
@@ -1,0 +1,4 @@
+metadata:
+  automatic_pack_namespace: true
+  namespace_override: "Summer::Swim"
+  autoload_glob: ''

--- a/spec/fixtures/rails-7.0/packs/summer/swim/trunks.rb
+++ b/spec/fixtures/rails-7.0/packs/summer/swim/trunks.rb
@@ -1,0 +1,1 @@
+class Summer::Swim::Trunks; end


### PR DESCRIPTION
Rails conventions for app/controllers, app/domain etc are not very useful for projects defining a large domain and utilizing packs to organize code.

This change allows adding application code to the eager load path located at the root of where the package.yml is defined giving the user full control of the file structure.

previously you could have a subpacks that looked like this:

```
- packs/
-   accounting/
-     package.yml
-     app/
-       public/
-         api.rb
-       domain/
-         subprocess/
-           package.yml
-           run_subprocess.rb
-         subprocess2/
-           package.yml
-           run_subprocess.rb

```

The subpack works fine, but all of the dependencies have to reference into the rails code structure, i.e:

```
dependencies:
  - packs/accounting/app/domain/subprocess
```

Specifying autoload_glob allows you to have complete control for structuring your pack.

```
-   accounting/
-     package.yml
-     app/
-       public/
-         api.rb
-     subprocess/
-       package.yml
-       run_subprocess.rb
-     subprocess2/
-       package.yml
-       run_subprocess.rb

```

Dependencies can referece the pack by:

```
dependencies:
  - packs/accounting/subprocess
```