### PR TITLE
Fix Dependabot by bumping required_ruby_version to >= 3.2.0

### DIFF
--- a/automatic_namespaces.gemspec
+++ b/automatic_namespaces.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.summary = "Modify autoloading to assume all files within a directory belong in a namespace"
   spec.homepage = "https://github.com/gap777/automatic_namespaces"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 2.6.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   if spec.respond_to?(:metadata)
     spec.metadata["homepage_uri"] = spec.homepage


### PR DESCRIPTION
## Summary
- Bumps `required_ruby_version` from `>= 2.6.0` to `>= 3.2.0` in the gemspec
- Dependabot's bundler updater falls back to Ruby 2.6.9 when it can't use the `.ruby-version` (4.0.2), causing all Rails 8.x security patch resolutions to fail
- This constraint was already too low since `packs-rails` requires >= 3.1 and Rails 8.x requires >= 3.2

## Test plan
- [ ] Verify Dependabot security updates run successfully after merge
- [ ] Confirm `bundle install` still works in local/CI environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)